### PR TITLE
clamavr_reload(): cl_engine_free() and cl_engine_new() before cl_load()

### DIFF
--- a/ext/clamav/clamav.c
+++ b/ext/clamav/clamav.c
@@ -107,12 +107,23 @@ static VALUE clamavr_reload(VALUE self) {
     if(state == 1) {
         const char *dbdir;
         dbdir = cl_retdbdir();
+        if(ptr->root != NULL) {
+            cl_engine_free(ptr->root);
+            ptr->root = cl_engine_new();
+            ptr->signo = 0;
+        }
         ret = cl_load(dbdir, ptr->root, &ptr->signo, FIX2INT(ptr->db_options));
         if(ret != CL_SUCCESS) {
             rb_raise(rb_eRuntimeError, "cl_load() error: %s\n", cl_strerror(ret));
         }
         cl_statfree(&ptr->dbstat);
         cl_statinidir(dbdir, &ptr->dbstat);
+
+        ret = cl_engine_compile(ptr->root);
+        if(ret != CL_SUCCESS) {
+            rb_raise(rb_eRuntimeError, "cl_engine_compile() error: %s\n", cl_strerror(ret));
+            cl_engine_free(ptr->root);
+        }
     }
     return INT2FIX(state);
 }


### PR DESCRIPTION
I was trying to use your Ruby bindings for `libclamav 0.97.6` and noticed that `reload()` wasn't working properly and would cause libclamav to error out with:

```
LibClamAV Error: cl_load(): can't load new databases when engine is already compiled
RuntimeError - cl_load() error: Invalid argument passed to function
```

With my very little C knowledge I traced it down to this piece of code missing where you need to actually call `cl_engine_free()` and then `cl_engine_new()`

I crossed referenced it with [clamav api docs](http://www.clamav.net/doc/latest/html/node43.html)

**DISCLAIMER:** I have not tested this with `libclamav 0.96.x` (yet).

Opening Pull Request for visibility, and discussion.
